### PR TITLE
DI-2804 테이블 데이터가 없는 경우에 에러 메세지를 보여줌

### DIFF
--- a/dodotable/environment/__init__.py
+++ b/dodotable/environment/__init__.py
@@ -31,6 +31,9 @@ class Environment(object):
     def get_session(self):
         raise NotImplementedError()
 
+    def get_locale(self):
+        return 'ko'
+
     def isinstance(self, instance, cls):
         if not isinstance(cls, type):
             try:

--- a/dodotable/environment/flask.py
+++ b/dodotable/environment/flask.py
@@ -34,3 +34,13 @@ class FlaskEnvironment(Environment):
             return None
         else:
             return session
+
+    def get_locale(self):
+        # FIXME
+        # 현재 도도테이블을 사용하는 모든 Flask 서비스에서 공통적으로 정의되는
+        # 로케일 판별 수단이 뭐가 있을지 모르겠어서 일단 임시로 리퀘스트의
+        # accept_language를 사용합니다.
+        try:
+            return request.accept_languages.best_match(['ko', 'jp', 'en'])
+        except:
+            return 'ko'

--- a/dodotable/templates/table.html
+++ b/dodotable/templates/table.html
@@ -31,9 +31,17 @@
     </thead>
 
     <tbody>
-      {% for row in table.rows %}
-      {{ row|safe }}
-      {% endfor %}
+      {%- if table.rows -%}
+        {% for row in table.rows %}
+        {{ row|safe }}
+        {% endfor %}
+      {%- else -%}
+        <tr>
+          <td class="table-empty-data" colspan="{{ table.columns | length }}">
+            등록된 데이터가 없습니다.
+          </td>
+        </tr>
+      {%- endif -%}
     </tbody>
   </table>
 

--- a/dodotable/templates/table.html
+++ b/dodotable/templates/table.html
@@ -38,7 +38,13 @@
       {%- else -%}
         <tr>
           <td class="table-empty-data" colspan="{{ table.columns | length }}">
-            등록된 데이터가 없습니다.
+            {%- if get_locale() == 'ko' -%}
+              등록된 데이터가 없습니다.
+            {%- else if get_locale() == 'jp' -%}
+              登録されたデータがありません。
+            {%- else -%}
+              No result found.
+            {%- endif -%}
           </td>
         </tr>
       {%- endif -%}


### PR DESCRIPTION
테이블의 초기 상태라던지 검색 결과가 없는 경우에 빈 `tbody`대신 에러메세지 한 줄을 보여주는 PR입니다. 국제화 관련해서는 [여기](https://i.spoqa.com/browse/DI-2804)에서 대화를 나누긴 했는데 일단 빠르게 진행할 수 있는 더 나은 방법이 떠오르지 않아서 리뷰를 받으려는 심산으로 PR을 날립니다.

현재는 그냥 `'ko'`를 디폴트로 갖고 `flask.request.accept_languages`를 기반으로 추론하는 방식으로만 짜 놨습니다. 일단 `babel`을 사용하지 않은 이유는 제가 코드베이스랑 아직 친숙하지 않아서, 도도테이블을 사용하는 모든 `Flask` 앱에서 항상 있을 거라고 가정할 수 있는 로케일 판별수단이 저것뿐이라고 생각해서인데요. 저것보단 더 나아질 수 있을 것 같은데 쉬운 방법이 안 떠오르네요... 

그리고 `gettext`를 붙이지 않고 그냥 `if-then-else`로 처리한 이유는 지금 국제화가 필요한 메세지가 이 곳 딱 하나 뿐이라고 당장 야크셰이빙을 너무 많이 하고 싶지 않았기 때문이구요. 리뷰/제안 부탁드립니당 @admire93 @dahlia 