### PR TITLE
Avoid auto-escaping in cell.html

### DIFF
--- a/dodotable/__init__.py
+++ b/dodotable/__init__.py
@@ -2,5 +2,5 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 """
-__version_info__ = 0, 3, 2
+__version_info__ = 0, 3, 3
 __version__ = '.'.join(str(v) for v in __version_info__)

--- a/dodotable/templates/cell.html
+++ b/dodotable/templates/cell.html
@@ -1,3 +1,3 @@
 <td {%-if cell.classes|length > 0 %} class="{{ " ".join(cell.classes) }}"{%-endif-%}>
-  {{ cell.repr(cell.data) }}
+  {{ cell.repr(cell.data) | safe}}
 </td>


### PR DESCRIPTION
There was an issue invoked by auto-escaping HTML in contract-service. This PR resolves that.