### PR TITLE
DI-3150

### DIFF
--- a/dodotable/__init__.py
+++ b/dodotable/__init__.py
@@ -2,5 +2,5 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 """
-__version_info__ = 0, 3, 5
+__version_info__ = 0, 3, 6
 __version__ = '.'.join(str(v) for v in __version_info__)

--- a/dodotable/condition.py
+++ b/dodotable/condition.py
@@ -165,7 +165,7 @@ class IlikeSet(_Filter, Queryable, Renderable):
 
     def __query__(self):
         filter_ = []
-        for column in self.table.columns:
+        for column in self.table._columns:
             for f in column.filters:
                 if isinstance(f, Ilike) and f.__query__() is not None:
                     filter_.append(f.__query__())

--- a/dodotable/schema.py
+++ b/dodotable/schema.py
@@ -136,7 +136,10 @@ class Column(Schema, Renderable):
     :param list filters: 정렬 기준
     :param function _repr: 보여질 형식
     :param bool sortable: 정렬 가능 여부
-    :param bool visible: 보일지 말지의 여부
+    :param bool visible: 테이블에 해당 칼럼이 보일지 말지의 여부.
+                         해당 값이 False여도
+                         :class:`~dodotable.condition.IlikeSet`의 필터에는
+                         보이므로 검색에는 사용할 수 있습니다.
 
     """
 

--- a/dodotable/templates/ilike_set.html
+++ b/dodotable/templates/ilike_set.html
@@ -5,7 +5,7 @@
 
    <form method="GET" action="{{ build_url(**qs) }}" class="search-filter-wrap">
      <select name="{{ filter.arg_type_name }}" class="form-control search-filter">
-       {% for column in filter.table.columns %}
+       {% for column in filter.table._columns %}
          {%- for filter in column.filters -%}
            {%- if isinstance(filter, 'dodotable.condition:Ilike') -%}
              <option value="{{ column.attr }}"


### PR DESCRIPTION
도도테이블 격변기를 거치면서 도도인사이트에 있던 `Column` 클래스의 `visible` 필드를 수입해왔는데요. 기존에 인사이트에서는 `visible=False`인 경우 테이블 자체에는 보여주지 않되 검색 필터로는 사용이 가능하게 되어 있었습니다. (애초에 그 기능을 위해 `visible` 필드가 생겨남) 저의 꼼꼼하지 못함으로 필터쪽에서도 없애버렸습니다 :quick-halbok: 해당 동작을 다시 되살리는 PR입니다.