### PR TITLE
Replace import-order with flake8-import-order-spoqa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs/_build
 .DS_Store
 
 .cache
+.eggs
 
 .tox
 *.mo

--- a/dodotable/condition.py
+++ b/dodotable/condition.py
@@ -3,7 +3,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 """
-import six
+from six import string_types
 from sqlalchemy.sql.expression import asc, desc, or_
 
 from .exc import BadChoice
@@ -208,7 +208,7 @@ class Order(Queryable):
         asc_order = cls.asc_order_name(attr)
         desc_order = cls.desc_order_name(attr)
         order = None
-        if not order_by or not isinstance(order_by, six.string_types):
+        if not order_by or not isinstance(order_by, string_types):
             return None
         for o in order_by.split(','):
             if o.strip() == asc_order:

--- a/dodotable/environment/flask.py
+++ b/dodotable/environment/flask.py
@@ -63,6 +63,7 @@ one of environment class, and use it in your table.
 
 """
 from __future__ import absolute_import
+
 from flask import request
 
 from . import Environment

--- a/dodotable/util.py
+++ b/dodotable/util.py
@@ -9,7 +9,7 @@ import numbers
 import re
 
 from jinja2 import Environment, PackageLoader
-import six
+from six import PY2, text_type
 
 
 __all__ = (
@@ -82,9 +82,9 @@ def _get_data(data, attribute_name, default):
     return __data__(data, name_chain) or default
 
 
-if six.PY2:
+if PY2:
     def to_str(x):
-        if isinstance(x, six.text_type):
+        if isinstance(x, text_type):
             return x
         if isinstance(x, numbers.Number):
             x = str(x)

--- a/pre-commit
+++ b/pre-commit
@@ -27,4 +27,5 @@ run import-order \
   --exclude=docs \
   --exclude=tests \
   --exclude=.tox \
+  --exclude=.eggs \
   dodotable .

--- a/pre-commit
+++ b/pre-commit
@@ -22,10 +22,4 @@ else
   }
   flake8_benchmark="--benchmark"
 fi
-run flake8 --exclude=docs,.tox .
-run import-order \
-  --exclude=docs \
-  --exclude=tests \
-  --exclude=.tox \
-  --exclude=.eggs \
-  dodotable .
+run flake8 .

--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,6 @@ def get_version():
             raise ValueError('could not find __version_info__')
 
 
-tests_require = [
-    'lxml',
-    'pytest >= 2.7.0',
-    'tox >= 2.1.1',
-    'import-order',
-    'flake8',
-]
 install_requires = [
     'setuptools',
     'Flask',
@@ -66,11 +59,7 @@ setup(
         'dodotable': ['locale/*/LC_MESSAGES/*.mo', 'templates/*.html'],
     },
     install_requires=get_install_requirements(install_requires),
-    extras_require={
-        'tests': tests_require,
-    },
     setup_requires=['Babel'],
-    tests_require=tests_require,
     message_extractors={
         'dodotable': [('**.py', 'python', None)],
         'dodotable/templates': [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import ast
 import sys
+
 from setuptools import find_packages, setup
 
 

--- a/tests/condition_test.py
+++ b/tests/condition_test.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
-from pytest import mark
-
-from dodotable.condition import (Ilike, IlikeSet, SelectFilter, IlikeAlias,
-                                 create_search_name)
-from dodotable.schema import Table, Column
-from dodotable.util import camel_to_underscore
 from mock import PropertyMock, patch
+from pytest import mark
 
 from .entities import Music, Tag
 from .helper import (DodotableTestEnvironment, compare_html, pager_html,
                      table_html)
+from dodotable.condition import (Ilike, IlikeSet, IlikeAlias, SelectFilter,
+                                 create_search_name)
+from dodotable.schema import Column, Table
+from dodotable.util import camel_to_underscore
 
 
 @patch('dodotable.schema.Schema.environment', new_callable=PropertyMock,

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-import lxml.html.diff
 import re
 try:
     from urllib import unquote
 except ImportError:
     from urllib.parse import unquote
+
+from lxml.html.diff import htmldiff
 
 from dodotable.environment import Environment
 
@@ -38,7 +39,7 @@ def html_unquote(html):
 def compare_html(actual, expected):
     _actual = removed_spaces(actual)
     _expected = removed_spaces(expected)
-    diff = html_unquote(lxml.html.diff.htmldiff(_actual, _expected))
+    diff = html_unquote(htmldiff(_actual, _expected))
     for i, (a, e) in enumerate(zip(_actual, _expected)):
         if a != e:
             print(i)

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from dodotable.schema import Cell, Column, Row, Table, Pager
-from mock import patch, PropertyMock
+from mock import PropertyMock, patch
 
 from .entities import Music
-from .helper import (compare_html, DodotableTestEnvironment, pager_html,
+from .helper import (DodotableTestEnvironment, compare_html, pager_html,
                      table_html)
+from dodotable.schema import Cell, Column, Row, Table, Pager
 
 
 def test_cell():

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,10 +1,10 @@
-import six
+from six import text_type
 
 from dodotable.util import string_literal
 
 
 def test_string_literal():
-    assert isinstance(string_literal(1), six.text_type)
-    assert isinstance(string_literal(1.1), six.text_type)
-    assert isinstance(string_literal('hello'), six.text_type)
-    assert isinstance(string_literal(u'hello'), six.text_type)
+    assert isinstance(string_literal(1), text_type)
+    assert isinstance(string_literal(1.1), text_type)
+    assert isinstance(string_literal('hello'), text_type)
+    assert isinstance(string_literal(u'hello'), text_type)

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,16 @@ deps=
     lxml
     mock
     pytest
+    pytest-flake8 >= 0.8.1
     flake8 >= 3.3.0
     flake8-import-order-spoqa >= 1.0.0
 commands=
-    pytest -v
+    pytest {posargs:-v}
     flake8 .
+
+[pytest]
+addopts = --flake8
+testpaths = dodotable/ tests/
 
 [flake8]
 exclude = .eggs,.tox,docs

--- a/tox.ini
+++ b/tox.ini
@@ -7,14 +7,13 @@ deps=
     lxml
     mock
     pytest
-    flake8
-    import-order
+    flake8 >= 3.3.0
+    flake8-import-order-spoqa >= 1.0.0
 commands=
-    py.test -v
-    flake8 --exclude=docs,.tox,.eggs .
-    import-order \
-      --exclude=docs \
-      --exclude=tests \
-      --exclude=.tox \
-      --exclude=.eggs \
-      dodotable .
+    pytest -v
+    flake8 .
+
+[flake8]
+exclude = .eggs,.tox,docs
+import-order-style = spoqa
+application-import-names = dodotable, tests

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,10 @@ deps=
     import-order
 commands=
     py.test -v
-    flake8 --exclude=docs,.tox .
+    flake8 --exclude=docs,.tox,.eggs .
     import-order \
       --exclude=docs \
       --exclude=tests \
       --exclude=.tox \
+      --exclude=.eggs \
       dodotable .


### PR DESCRIPTION
- Invoke flake8 with pytest altogether.
- Replace import-order with flake8-import-order-spoqa.
- Remove `tests_require` in setup.py which was unnecessary and duplicate with tox.ini's `deps`.