### PR TITLE
Fix MultiDict bug

### DIFF
--- a/dodotable/environment/flask.py
+++ b/dodotable/environment/flask.py
@@ -113,5 +113,5 @@ def default_locale_selector():
     # accept_language를 사용합니다.
     try:
         return request.accept_languages.best_match(['ko', 'jp', 'en'])
-    except:
+    except Exception:
         return 'ko'

--- a/dodotable/environment/flask.py
+++ b/dodotable/environment/flask.py
@@ -93,7 +93,7 @@ class FlaskEnvironment(Environment):
                 arg.pop(attr)
         arg.update(kwargs.items())
         rule = request.url_rule
-        result = rule.build(arg)
+        result = rule.build({k: v for k, v in arg.items()})
         return result[1]
 
     def get_session(self):

--- a/dodotable/helper.py
+++ b/dodotable/helper.py
@@ -16,7 +16,7 @@ class _Helper(Schema):
 
 
 class Limit(_Helper, Renderable, Queryable):
-    """querystring 중에 ``limit``\ 를 조작해서 100개보기 같은 기능을
+    """querystring 중에 ``limit`` 를 조작해서 100개보기 같은 기능을
     제공합니다.
 
     """

--- a/dodotable/util.py
+++ b/dodotable/util.py
@@ -25,7 +25,7 @@ all_cap_re = re.compile('([a-z0-9])([A-Z])')
 
 
 def camel_to_underscore(name):
-    """CamelCase로 주어진 ``name``\ 을 underscore_with_lower_case로 변환합니다
+    """CamelCase로 주어진 ``name`` 을 underscore_with_lower_case로 변환합니다
 
     .. code-block:: python
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py34,py35,pypy
 [testenv]
 deps=
     sqlalchemy
-    lxml
+    lxml < 4.4.0
     mock
     pytest
     pytest-flake8 >= 0.8.1


### PR DESCRIPTION
`flask.request.args` property에서 MultiDict를 돌려주는데, 이를 `werkzeug.routing.Rule.build` 에서 해석하면서 MultiDict의 value를 list 타입으로 오해하는 버그가 있습니다. MultiDict를 dict로 강제로 변환하여 버그를 수정합니다.